### PR TITLE
Feat: GUI 속성 중 `zOrder`, `rank` 추가

### DIFF
--- a/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/data/infoWindowOption/InfoWindowOptionExtension.kt
+++ b/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/data/infoWindowOption/InfoWindowOptionExtension.kt
@@ -66,6 +66,9 @@ fun JSONObject.toNativeInfoWindowOptions(): InfoWindowOptions? {
     // Set visibility
     options.isVisible = this.optBoolean("isVisible", true)
 
+    // Set zOrder
+    options.zOrder = this.optInt("zOrder", 0)
+
     // Handle custom body or fallback to text
     val hasCustomBody = this.optBoolean("hasCustomBody", false)
 

--- a/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/data/labelOption/LabelOption.kt
+++ b/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/data/labelOption/LabelOption.kt
@@ -8,10 +8,10 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 
 @ExperimentalEncodingApi
 data class LabelOption(
-    val id: String, val latLng: LatLng, val image: Bitmap?
+    val id: String, val latLng: LatLng, val image: Bitmap?, val rank: Long = 0,
 ) {
     constructor(
-        id: String, latLng: LatLng, image: String?,
+        id: String, latLng: LatLng, image: String?, rank: Long = 0,
     ) : this(
         id, latLng, if (image == null) {
             null

--- a/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/data/labelOption/LabelOptionExtension.kt
+++ b/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/data/labelOption/LabelOptionExtension.kt
@@ -15,5 +15,6 @@ fun JSONObject.toLabelOptionOrNull(): LabelOption? {
         this.getString("id"),
         this.getJSONObject("latLng").toLatLng(),
         this.optString("base64EncodedImage"),
+        this.optLong("rank", 0),
     )
 }

--- a/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/view/KakaoMapController.kt
+++ b/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/view/KakaoMapController.kt
@@ -360,6 +360,7 @@ class KakaoMapController(
                 labelOption.latLng,
             )
         option.setStyles(labelStyles)
+        option.rank = labelOption.rank
 
         kMap.labelManager?.layer?.addLabel(option)
 
@@ -407,6 +408,7 @@ class KakaoMapController(
             val labelStyles = LabelStyles.from(labelStyle)
             val labelOption = LabelOptions.from(option.id, option.latLng)
             labelOption.setStyles(labelStyles)
+            labelOption.setRank(option.rank)
 
             layer.addLabel(labelOption)
         }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -268,6 +268,7 @@ class _KakaoMapExampleScreenState extends State<KakaoMapExampleScreen> {
         id: id,
         latLng: position,
         base64EncodedImage: ExampleAssets.marker2x,
+        rank: 9999,
       ),
     );
     showSnackBar('📌 Marker "$id" added');
@@ -506,6 +507,11 @@ class _KakaoMapExampleScreenState extends State<KakaoMapExampleScreen> {
         title: title,
         snippet: snippet,
         offset: const InfoWindowOffset(x: 0, y: -20),
+        zOrder: id.contains('jamsil') ? 1000 : 0,
+        body: id.contains('jamsil')
+            ? const GuiImage.fromBase64(
+                base64EncodedImage: ExampleAssets.infoWindowBackgroundImage2x)
+            : null,
       ),
     );
     showSnackBar('💬 InfoWindow "$id" added');

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -510,7 +510,7 @@ class _KakaoMapExampleScreenState extends State<KakaoMapExampleScreen> {
         zOrder: id.contains('jamsil') ? 1000 : 0,
         body: id.contains('jamsil')
             ? const GuiImage.fromBase64(
-                base64EncodedImage: ExampleAssets.infoWindowBackgroundImage2x)
+                base64EncodedImage: ExampleAssets.infoWindowBackgroundImage2x,)
             : null,
       ),
     );

--- a/ios/kakao_maps_flutter/Package.swift
+++ b/ios/kakao_maps_flutter/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
   name: "kakao_maps_flutter",
   platforms: [
-    .iOS(.v13)
+    .iOS("13.0")
   ],
   products: [
     .library(

--- a/ios/kakao_maps_flutter/Sources/kakao_maps_flutter/Extensions/InfoWindowOptionX.swift
+++ b/ios/kakao_maps_flutter/Sources/kakao_maps_flutter/Extensions/InfoWindowOptionX.swift
@@ -19,6 +19,7 @@ extension Dictionary where Key == String, Value == Any {
         
         let infoWindow = InfoWindow(id)
         infoWindow.position = position
+        infoWindow.zOrder = self["zOrder"] as? Int ?? 0
         
         if hasCustomBody {
             // Handle custom GuiView body

--- a/ios/kakao_maps_flutter/Sources/kakao_maps_flutter/KakaoMapController.swift
+++ b/ios/kakao_maps_flutter/Sources/kakao_maps_flutter/KakaoMapController.swift
@@ -371,7 +371,7 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
             let poiStyleID = createPoiStyleWithImage(image)
             let poiOption = PoiOptions(styleID: poiStyleID, poiID: id)
             poiOption.clickable = true
-            poiOption.rank = 0
+            poiOption.rank = args["rank"] as? Int ?? 0
             
             let poi = targetLayer.addPoi(option: poiOption, at: point)
             poi?.show()
@@ -427,7 +427,7 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
                 let poiStyleID = createPoiStyleWithImage(image)
                 let poiOption = PoiOptions(styleID: poiStyleID, poiID: id)
                 poiOption.clickable = true
-                poiOption.rank = 0
+                poiOption.rank = args["rank"] as? Int ?? 0
                 
                 let poi = targetLayer.addPoi(option: poiOption, at: point)
                 poi?.show()

--- a/lib/src/data/label/label_option.dart
+++ b/lib/src/data/label/label_option.dart
@@ -18,6 +18,7 @@ class LabelOption extends Data {
     required this.id,
     required this.latLng,
     required this.base64EncodedImage,
+    this.rank,
   });
 
   /// Creates a LabelOption from raw image bytes.
@@ -28,11 +29,13 @@ class LabelOption extends Data {
     required String id,
     required LatLng latLng,
     required Uint8List imageBytes,
+    int? rank,
   }) =>
       LabelOption(
         id: id,
         latLng: latLng,
         base64EncodedImage: base64.encode(imageBytes),
+        rank: rank,
       );
 
   /// The unique identifier for this label.
@@ -46,10 +49,18 @@ class LabelOption extends Data {
   /// If null, a default marker icon will be used.
   final String? base64EncodedImage;
 
+  /// 지도 렌더링 순위
+  ///
+  /// [rank] 값이 높을수록 높은 우선순위를 가집니다.
+  /// - Android: LabelOption 렌더링 순위
+  /// - iOS: PoiOption 렌더링 순위
+  final int? rank;
+
   @override
   Map<String, Object?> toJson() => <String, Object?>{
         'id': id,
         'latLng': latLng.toJson(),
         'base64EncodedImage': base64EncodedImage,
+        'rank': rank,
       };
 }

--- a/lib/src/data/map_widget/info_window/info_window_option.dart
+++ b/lib/src/data/map_widget/info_window/info_window_option.dart
@@ -15,6 +15,7 @@ class InfoWindowOption extends Data {
   /// The [isVisible] determines whether the info window should be shown initially.
   /// The [offset] allows positioning the info window relative to its anchor point.
   /// The [bodyOffset] allows positioning the body relative to its anchor point.
+  /// The [zOrder] is the rendering order of the [InfoWindow]
   const InfoWindowOption({
     required this.id,
     required this.latLng,
@@ -25,6 +26,7 @@ class InfoWindowOption extends Data {
     this.isVisible = true,
     this.offset = const InfoWindowOffset(x: 0, y: 0),
     this.bodyOffset = const InfoWindowOffset(x: 0, y: 0),
+    this.zOrder,
   });
 
   /// Creates a simple text-based InfoWindow (legacy style).
@@ -38,6 +40,7 @@ class InfoWindowOption extends Data {
     this.isVisible = true,
     this.offset = const InfoWindowOffset(x: 0, y: 0),
     this.bodyOffset = const InfoWindowOffset(x: 0, y: 0),
+    this.zOrder,
   })  : body = null,
         tail = null;
 
@@ -52,6 +55,7 @@ class InfoWindowOption extends Data {
     this.isVisible = true,
     this.offset = const InfoWindowOffset(x: 0, y: 0),
     this.bodyOffset = const InfoWindowOffset(x: 0, y: 0),
+    this.zOrder,
   })  : title = null,
         snippet = null;
 
@@ -87,6 +91,9 @@ class InfoWindowOption extends Data {
   /// Whether this InfoWindow uses custom GUI components.
   bool get hasCustomBody => body != null;
 
+  /// [LabelOption]과 렌더링 순위를 별도로 관리, [InfoWindowOption] 끼리만 서로 유효
+  final int? zOrder;
+
   @override
   Map<String, Object?> toJson() => <String, Object?>{
         'id': id,
@@ -99,6 +106,7 @@ class InfoWindowOption extends Data {
         'offset': offset.toJson(),
         'bodyOffset': bodyOffset.toJson(),
         'hasCustomBody': hasCustomBody,
+        'zOrder': zOrder,
       };
 }
 


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Summary

Added support for customizing rendering priorities of labels/POIs (`rank`) and rendering order of info windows (`zOrder`) in the Kakao Maps Flutter plugin. These enhancements improve the flexibility and visual control of map elements across Android, iOS, and Flutter layers.

## 🔗 Related Issues

* Closes #

## 🎯 Feature Details

### 🔖 Label and POI Enhancements

* Added `rank` property to `LabelOption` and `PoiOptions` to control rendering priority.
* Implemented across Android (`LabelOptionExtension.kt`, `KakaoMapController.kt`), iOS (`KakaoMapController.swift`), and Dart (`label_option.dart`).

### 🪟 Info Window Enhancements

* Introduced `zOrder` property in `InfoWindowOption` to manage overlay order of info windows.
* Implemented across Android (`InfoWindowOptionExtension.kt`), iOS (`InfoWindowOptionX.swift`), and Dart (`info_window_option.dart`).

### 💡 Example Updates

* Updated example app to demonstrate `rank` and `zOrder` usage in `main.dart`.

### 🧩 Miscellaneous

* iOS `Package.swift` updated to require platform version `"13.0"` for consistency.

### 📱 Screenshots/Demo

*No UI screenshots required; visual behavior shown in example app.*

### 🧪 Testing

* [ ] Unit tests added
* [ ] Widget tests added
* [x] Tested in example app
* [ ] Tested on multiple platforms

### 📚 Documentation

* [ ] README.md updated
* [ ] API documentation updated
* [x] Example code added

### ✅ Checklist

* [x] Code follows style guide
* [x] Self-review completed
* [ ] Tests added and passing
* [ ] Documentation updated
* [x] Verified in example app
