### PR TITLE
Feat: InfoWindow hide/show 기능 구현

### DIFF
--- a/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/view/KakaoMapController.kt
+++ b/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/view/KakaoMapController.kt
@@ -1060,6 +1060,41 @@ class KakaoMapController(
         }
     }
 
+    private fun setInfoWindowLayerVisible(args: JSONObject, result: MethodChannel.Result) {
+        require(::kMap.isInitialized) { "kakaoMap is not initialized" }
+
+        try {
+            val visible = args.optBoolean("visible", true)
+            val layer = kMap.mapWidgetManager?.infoWindowLayer
+            layer?.setVisible(visible)
+            // 현재 등록된 모든 InfoWindow에 대해 show/hide를 호출하여 상태를 일치시킴
+            val all = layer?.getAllInfoWindows()
+            if (all != null) {
+                for (win in all) {
+                    if (visible) win.show() else win.hide()
+                }
+            }
+            return result.success(null)
+        } catch (e: Exception) {
+            return result.error("E011", "Error setting InfoWindowLayer visibility: ${e.message}", null)
+        }
+    }
+
+    private fun setInfoWindowVisible(args: JSONObject, result: MethodChannel.Result) {
+        require(::kMap.isInitialized) { "kakaoMap is not initialized" }
+
+        try {
+            val id = args.getString("id")
+            val visible = args.optBoolean("visible", true)
+            val infoWindow = kMap.mapWidgetManager?.infoWindowLayer?.getInfoWindow(id)
+            if (infoWindow == null) return result.success(null)
+            if (visible) infoWindow.show() else infoWindow.hide()
+            return result.success(null)
+        } catch (e: Exception) {
+            return result.error("E012", "Error setting InfoWindow visibility: ${e.message}", null)
+        }
+    }
+
     private fun showCompass(result: MethodChannel.Result) {
         require(::kMap.isInitialized) { "kakaoMap is not initialized" }
 
@@ -1184,6 +1219,8 @@ class KakaoMapController(
             "removeInfoWindows" -> removeInfoWindows(asJSONObject(call.arguments), result)
             "updateInfoWindow" -> updateInfoWindow(asJSONObject(call.arguments), result)
             "clearInfoWindows" -> clearInfoWindows(result)
+            "setInfoWindowLayerVisible" -> setInfoWindowLayerVisible(asJSONObject(call.arguments), result)
+            "setInfoWindowVisible" -> setInfoWindowVisible(asJSONObject(call.arguments), result)
             "showCompass" -> showCompass(result)
             "hideCompass" -> hideCompass(result)
             "showScaleBar" -> showScaleBar(result)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -187,6 +187,10 @@ class _KakaoMapExampleScreenState extends State<KakaoMapExampleScreen> {
           onInfoWindowRemove: onInfoWindowRemove,
           onInfoWindowsAddAll: onInfoWindowsAddAll,
           onInfoWindowsClear: onInfoWindowsClear,
+          onInfoWindowLayerShow: onInfoWindowLayerShow,
+          onInfoWindowLayerHide: onInfoWindowLayerHide,
+          onShowSeoulInfoWindow: onShowSeoulInfoWindow,
+          onHideSeoulInfoWindow: onHideSeoulInfoWindow,
           onStaticMapButtonPressed: onStaticMapButtonPressed,
           onGuiInfoWindowCustomBubble: onGuiInfoWindowCustomBubble,
           onGuiInfoWindowComplex: onGuiInfoWindowComplex,
@@ -619,6 +623,31 @@ class _KakaoMapExampleScreenState extends State<KakaoMapExampleScreen> {
 
     await mapController!.clearInfoWindows();
     showSnackBar('🧹 All InfoWindows cleared');
+  }
+
+  // ===== New: InfoWindow visibility demo =====
+  Future<void> onInfoWindowLayerShow() async {
+    if (mapController == null) return;
+    await mapController!.setInfoWindowLayerVisible(visible: true);
+    showSnackBar('👁️ InfoWindow layer: visible');
+  }
+
+  Future<void> onInfoWindowLayerHide() async {
+    if (mapController == null) return;
+    await mapController!.setInfoWindowLayerVisible(visible: false);
+    showSnackBar('🙈 InfoWindow layer: hidden');
+  }
+
+  Future<void> onShowSeoulInfoWindow() async {
+    if (mapController == null) return;
+    await mapController!.setInfoWindowVisible(id: 'seoul_info', visible: true);
+    showSnackBar('👁️ Show "seoul_info"');
+  }
+
+  Future<void> onHideSeoulInfoWindow() async {
+    if (mapController == null) return;
+    await mapController!.setInfoWindowVisible(id: 'seoul_info', visible: false);
+    showSnackBar('🙈 Hide "seoul_info"');
   }
 
   Future<void> onInfoWindowsAddAll() async {

--- a/example/lib/widgets/feature_drawer.dart
+++ b/example/lib/widgets/feature_drawer.dart
@@ -26,6 +26,10 @@ class FeatureDrawer extends StatelessWidget {
     required this.onInfoWindowRemove,
     required this.onInfoWindowsAddAll,
     required this.onInfoWindowsClear,
+    required this.onInfoWindowLayerShow,
+    required this.onInfoWindowLayerHide,
+    required this.onShowSeoulInfoWindow,
+    required this.onHideSeoulInfoWindow,
     required this.onStaticMapButtonPressed,
     required this.onGuiInfoWindowCustomBubble,
     required this.onGuiInfoWindowComplex,
@@ -64,6 +68,10 @@ class FeatureDrawer extends StatelessWidget {
   final Future<void> Function(String) onInfoWindowRemove;
   final VoidCallback onInfoWindowsAddAll;
   final VoidCallback onInfoWindowsClear;
+  final VoidCallback onInfoWindowLayerShow;
+  final VoidCallback onInfoWindowLayerHide;
+  final VoidCallback onShowSeoulInfoWindow;
+  final VoidCallback onHideSeoulInfoWindow;
   final VoidCallback onStaticMapButtonPressed;
   final VoidCallback onGuiInfoWindowCustomBubble;
   final VoidCallback onGuiInfoWindowComplex;
@@ -332,6 +340,38 @@ class FeatureDrawer extends StatelessWidget {
                 enabled: isMapReady,
                 onTap: () {
                   onInfoWindowsClear();
+                  Navigator.of(context).pop();
+                },
+              ),
+              KakaoDrawerTile(
+                title: 'Show All InfoWindows (Layer Visible)',
+                enabled: isMapReady,
+                onTap: () {
+                  onInfoWindowLayerShow();
+                  Navigator.of(context).pop();
+                },
+              ),
+              KakaoDrawerTile(
+                title: 'Hide All InfoWindows (Layer Invisible)',
+                enabled: isMapReady,
+                onTap: () {
+                  onInfoWindowLayerHide();
+                  Navigator.of(context).pop();
+                },
+              ),
+              KakaoDrawerTile(
+                title: 'Show "seoul_info"',
+                enabled: isMapReady,
+                onTap: () {
+                  onShowSeoulInfoWindow();
+                  Navigator.of(context).pop();
+                },
+              ),
+              KakaoDrawerTile(
+                title: 'Hide "seoul_info"',
+                enabled: isMapReady,
+                onTap: () {
+                  onHideSeoulInfoWindow();
                   Navigator.of(context).pop();
                 },
               ),

--- a/ios/kakao_maps_flutter/Sources/kakao_maps_flutter/KakaoMapController.swift
+++ b/ios/kakao_maps_flutter/Sources/kakao_maps_flutter/KakaoMapController.swift
@@ -227,6 +227,10 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
             removeInfoWindows(call, result)
         case "clearInfoWindows":
             clearInfoWindows(result)
+        case "setInfoWindowLayerVisible":
+            setInfoWindowLayerVisible(call, result)
+        case "setInfoWindowVisible":
+            setInfoWindowVisible(call, result)
         case "showCompass":
             showCompass(result)
         case "hideCompass":
@@ -1052,6 +1056,38 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
         withKakaoMapView(result) { view in
             let guiManager = view.getGuiManager()
             let _ = guiManager.infoWindowLayer.clear()
+            result(nil)
+        }
+    }
+
+    private func setInfoWindowLayerVisible(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any], let visible = args["visible"] as? Bool else {
+            result(FlutterError(code: "E001", message: "Invalid arguments for setInfoWindowLayerVisible", details: nil))
+            return
+        }
+        withKakaoMapView(result) { view in
+            let guiManager = view.getGuiManager()
+            guiManager.infoWindowLayer.visible = visible
+            // 보조적으로 현재 등록된 InfoWindow 들의 show/hide 상태를 visible에 맞춰 정렬
+            if let all = guiManager.infoWindowLayer.getAllInfoWindows() {
+                for win in all {
+                    if visible { win.show() } else { win.hide() }
+                }
+            }
+            result(nil)
+        }
+    }
+
+    private func setInfoWindowVisible(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any], let id = args["id"] as? String, let visible = args["visible"] as? Bool else {
+            result(FlutterError(code: "E001", message: "Invalid arguments for setInfoWindowVisible", details: nil))
+            return
+        }
+        withKakaoMapView(result) { view in
+            let guiManager = view.getGuiManager()
+            if let win = guiManager.infoWindowLayer.getInfoWindow(guiName: id) {
+                if visible { win.show() } else { win.hide() }
+            }
             result(nil)
         }
     }

--- a/lib/src/platform/kakao_map_controller/kakao_map_controller.dart
+++ b/lib/src/platform/kakao_map_controller/kakao_map_controller.dart
@@ -318,6 +318,23 @@ class KakaoMapController extends KakaoMapControllerPlatform {
     await _platform._callMethod(const ClearInfoWindows());
   }
 
+  /// InfoWindow 레이어 전체의 표시 여부를 설정합니다.
+  ///
+  /// 호출 시점까지 추가된 모든 InfoWindow를 일괄 hide/show 합니다.
+  Future<void> setInfoWindowLayerVisible({required bool visible}) async {
+    await _platform._callMethod(SetInfoWindowLayerVisible(visible: visible));
+  }
+
+  /// 특정 InfoWindow의 표시 여부를 설정합니다.
+  ///
+  /// 해당 ID의 InfoWindow가 존재할 경우 hide/show 합니다.
+  Future<void> setInfoWindowVisible({
+    required String id,
+    required bool visible,
+  }) async {
+    await _platform._callMethod(SetInfoWindowVisible(id: id, visible: visible));
+  }
+
   /// Shows the compass on the map.
   ///
   /// The compass will be displayed according to its current configuration.

--- a/lib/src/platform/kakao_map_method_call/kakao_map_method_call.dart
+++ b/lib/src/platform/kakao_map_method_call/kakao_map_method_call.dart
@@ -453,6 +453,35 @@ final class ClearInfoWindows extends KakaoMapMethodCall<void> {
   Map<String, Object?>? encode() => null;
 }
 
+// InfoWindow visibility controls
+final class SetInfoWindowLayerVisible extends KakaoMapMethodCall<void> {
+  const SetInfoWindowLayerVisible({required this.visible});
+
+  final bool visible;
+
+  @override
+  String get name => 'setInfoWindowLayerVisible';
+
+  @override
+  Map<String, Object?>? encode() => {'visible': visible};
+}
+
+final class SetInfoWindowVisible extends KakaoMapMethodCall<void> {
+  const SetInfoWindowVisible({required this.id, required this.visible});
+
+  final String id;
+  final bool visible;
+
+  @override
+  String get name => 'setInfoWindowVisible';
+
+  @override
+  Map<String, Object?>? encode() => {
+        'id': id,
+        'visible': visible,
+      };
+}
+
 final class ShowCompass extends KakaoMapMethodCall<void> {
   const ShowCompass();
 
@@ -700,8 +729,10 @@ final class HideLodMarkers extends KakaoMapMethodCall<void> {
 }
 
 final class SetLodMarkerLayerClickable extends KakaoMapMethodCall<void> {
-  const SetLodMarkerLayerClickable(
-      {required this.layerId, required this.clickable});
+  const SetLodMarkerLayerClickable({
+    required this.layerId,
+    required this.clickable,
+  });
 
   final String layerId;
   final bool clickable;


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 요약
InfoWindow의 가시성을 전역(모든 InfoWindow) 및 개별(ID별)로 제어할 수 있는 기능을 Android, iOS, Dart 레이어에 추가했습니다.

## 🔗 관련 이슈
- Closes #

## 🎯 기능 상세 설명

### 주요 변경사항
- **InfoWindow 가시성 제어 API**
 - `setInfoWindowLayerVisible`: 전체 InfoWindow 레이어 표시/숨기기
 - `setInfoWindowVisible`: 특정 ID의 InfoWindow 표시/숨기기
 - Android/iOS 네이티브 구현 완료
 - Dart 플랫폼 인터페이스 메서드 추가

- **예제 앱 업데이트**
 - 모든 InfoWindow 표시/숨기기 버튼 추가
 - 특정 InfoWindow(`seoul_info`) 토글 기능 추가
 - UI 드로어에 새로운 컨트롤 추가



### 🧪 테스트
- [ ] 단위 테스트 추가
- [ ] 위젯 테스트 추가
- [x] 예제 앱에서 테스트
- [x] 다양한 플랫폼에서 테스트 (Android/iOS)

### 📚 문서 업데이트
- [ ] README.md 업데이트
- [ ] API 문서 업데이트
- [x] 예제 코드 추가

### ✅ 체크리스트
- [x] 코드 스타일 가이드 준수
- [x] 자체 리뷰 완료
- [ ] 테스트 추가 및 통과
- [ ] 문서 업데이트
- [x] 예제 앱에서 동작 확인