### PR TITLE
Feature: LabelManager, LabelLayer 계층 분리

### DIFF
--- a/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/view/KakaoMapController.kt
+++ b/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/view/KakaoMapController.kt
@@ -211,11 +211,11 @@ class KakaoMapController(
         )
     }
 
-    // Helper to get or create a normal LabelLayer
+    // Helper to get a normal LabelLayer (no implicit creation when layerId is provided)
     private fun getOrCreateLabelLayer(layerId: String?): LabelLayer? {
         val manager = kMap.labelManager ?: return null
         if (layerId.isNullOrEmpty()) return manager.layer
-        return manager.getLayer(layerId) ?: manager.addLayer(LabelLayerOptions.from(layerId))
+        return manager.getLayer(layerId)
     }
 
     private fun JSONObject.toMap(): Map<String, Any?> =
@@ -495,8 +495,8 @@ class KakaoMapController(
         require(::kMap.isInitialized) { "kakaoMap is not initialized" }
         val layerId = args.optString("layerId", "")
         if (layerId.isEmpty()) return result.error("E001", "layerId must not be empty", null)
-        val layer = kMap.labelManager?.getLayer(layerId) ?: kMap.labelManager?.addLayer(LabelLayerOptions.from(layerId))
-        layer?.removeAll()
+        val layer = kMap.labelManager?.getLayer(layerId) ?: return result.success(null)
+        layer.removeAll()
         return result.success(null)
     }
 
@@ -520,8 +520,7 @@ class KakaoMapController(
         val layerId = args.optString("layerId", "")
         val visible = args.optBoolean("visible", true)
         if (layerId.isEmpty()) return result.error("E001", "layerId must not be empty", null)
-        val layer = kMap.labelManager?.getLayer(layerId) ?: kMap.labelManager?.addLayer(LabelLayerOptions.from(layerId))
-        if (layer == null) return result.success(null)
+        val layer = kMap.labelManager?.getLayer(layerId) ?: return result.success(null)
         layer.setVisible(visible)
         return result.success(null)
     }
@@ -530,8 +529,7 @@ class KakaoMapController(
         require(::kMap.isInitialized) { "kakaoMap is not initialized" }
         val layerId = args.optString("layerId", "")
         if (layerId.isEmpty()) return result.error("E001", "layerId must not be empty", null)
-        val layer = kMap.labelManager?.getLayer(layerId) ?: kMap.labelManager?.addLayer(LabelLayerOptions.from(layerId))
-        if (layer == null) return result.success(null)
+        val layer = kMap.labelManager?.getLayer(layerId) ?: return result.success(null)
         layer.showAllLabels()
         return result.success(null)
     }
@@ -540,8 +538,7 @@ class KakaoMapController(
         require(::kMap.isInitialized) { "kakaoMap is not initialized" }
         val layerId = args.optString("layerId", "")
         if (layerId.isEmpty()) return result.error("E001", "layerId must not be empty", null)
-        val layer = kMap.labelManager?.getLayer(layerId) ?: kMap.labelManager?.addLayer(LabelLayerOptions.from(layerId))
-        if (layer == null) return result.success(null)
+        val layer = kMap.labelManager?.getLayer(layerId) ?: return result.success(null)
         layer.hideAllLabels()
         return result.success(null)
     }

--- a/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/view/KakaoMapController.kt
+++ b/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/view/KakaoMapController.kt
@@ -869,11 +869,11 @@ class KakaoMapController(
     private fun getCenter(result: MethodChannel.Result) {
         require(::kMap.isInitialized) { "kakaoMap is not initialized" }
 
-        val center = kMap.cameraPosition?.position
+        val center = kMap.cameraPosition?.position ?: return result.success(null)
         return result.success(
             mapOf(
-                "latitude" to center?.latitude,
-                "longitude" to center?.longitude,
+                "latitude" to center.latitude,
+                "longitude" to center.longitude,
             )
         )
     }
@@ -901,12 +901,12 @@ class KakaoMapController(
         val dx = point.getDouble("dx")
         val dy = point.getDouble("dy")
 
-        val latLng = kMap.fromScreenPoint(dx.toInt(), dy.toInt())
+        val latLng = kMap.fromScreenPoint(dx.toInt(), dy.toInt()) ?: return result.success(null)
 
         return result.success(
             mapOf(
-                "latitude" to latLng?.latitude,
-                "longitude" to latLng?.longitude,
+                "latitude" to latLng.latitude,
+                "longitude" to latLng.longitude,
             )
         )
     }

--- a/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/view/KakaoMapController.kt
+++ b/android/src/main/kotlin/io/seunghwanly/kakao_maps_flutter/view/KakaoMapController.kt
@@ -338,6 +338,12 @@ class KakaoMapController(
         }
     }
 
+    private fun JSONObject.extractLayerId(): String? {
+        // optString(key, fallback)은 키가 없거나 값이 null일 때 fallback을 반환합니다.
+        // 따라서 기존의 긴 if문과 완벽하게 동일한 역할을 합니다.
+        return optString("layerId", null)
+    }
+
     private fun getZoomLevel(result: MethodChannel.Result) {
         require(::kMap.isInitialized) { "kakaoMap is not initialized" }
         val level = kMap.cameraPosition?.zoomLevel
@@ -381,8 +387,7 @@ class KakaoMapController(
                     null,
                 )
 
-        val requestedLayerId: String? = if (args.has("layerId") && !args.isNull("layerId")) args.optString("layerId", null) else null
-        val currentLayer: LabelLayer = getOrCreateLabelLayer(requestedLayerId)
+        val currentLayer: LabelLayer = getOrCreateLabelLayer(args.extractLayerId())
             ?: return result.error(
                 "E002",
                 "Either LabelManager or its layer is null",
@@ -427,8 +432,7 @@ class KakaoMapController(
             )
         }
 
-        val requestedLayerId: String? = if (args.has("layerId") && !args.isNull("layerId")) args.optString("layerId", null) else null
-        val layer: LabelLayer? = getOrCreateLabelLayer(requestedLayerId)
+        val layer: LabelLayer? = getOrCreateLabelLayer(args.extractLayerId())
         layer?.getLabel(labelId)?.remove()
 
         return result.success(null)
@@ -439,8 +443,8 @@ class KakaoMapController(
         require(::kMap.isInitialized)
 
         val options = args.getJSONArray("markers")
-        val requestedLayerId: String? = if (args.has("layerId") && !args.isNull("layerId")) args.optString("layerId", null) else null
-        val layer = getOrCreateLabelLayer(requestedLayerId) ?: return result.error("E002", "Layer is null", null)
+
+        val layer = getOrCreateLabelLayer(args.extractLayerId()) ?: return result.error("E002", "Layer is null", null)
 
         val labelOptions: MutableList<LabelOptions>  = mutableListOf()
 
@@ -474,8 +478,7 @@ class KakaoMapController(
     private fun removeMarkers(args: JSONObject, result: MethodChannel.Result) {
         require(::kMap.isInitialized)
 
-        val requestedLayerId: String? = if (args.has("layerId") && !args.isNull("layerId")) args.optString("layerId", null) else null
-        val layer = getOrCreateLabelLayer(requestedLayerId) ?: return result.error("E002", "Layer is null", null)
+        val layer = getOrCreateLabelLayer(args.extractLayerId()) ?: return result.error("E002", "Layer is null", null)
         val parsedIds = args.getJSONArray("ids")
 
         val labels: MutableList<Label> = mutableListOf()

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -239,6 +239,13 @@ class _KakaoMapExampleScreenState extends State<KakaoMapExampleScreen> {
 
     await mapController!.registerMarkerStyles(styles: markerStyles);
 
+    // Create default LabelLayer for normal markers before using addMarker/addMarkers
+    await mapController!.addMarkerLayer(
+      layerId: KakaoMapController.defaultLabelLayerId,
+      zOrder: 1000,
+      clickable: true,
+    );
+
     // Optionally prepare LOD layer immediately (iOS fully; Android zOrder only)
     await onLodCreateLayer();
   }
@@ -572,7 +579,7 @@ class _KakaoMapExampleScreenState extends State<KakaoMapExampleScreen> {
       SnackBar(
         content: Text(message),
         duration: duration ?? const Duration(seconds: 2),
-        behavior: SnackBarBehavior.fixed,
+        behavior: SnackBarBehavior.floating,
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -160,7 +160,7 @@ class _KakaoMapExampleScreenState extends State<KakaoMapExampleScreen> {
           enabled: isReady,
         ),
       ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+      floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
       drawer: ValueListenableBuilder<bool>(
         valueListenable: mapReadyNotifier,
         builder: (context, isReady, _) => FeatureDrawer(
@@ -579,7 +579,7 @@ class _KakaoMapExampleScreenState extends State<KakaoMapExampleScreen> {
       SnackBar(
         content: Text(message),
         duration: duration ?? const Duration(seconds: 2),
-        behavior: SnackBarBehavior.floating,
+        behavior: SnackBarBehavior.fixed,
       ),
     );
   }

--- a/ios/kakao_maps_flutter/Sources/kakao_maps_flutter/KakaoMapController.swift
+++ b/ios/kakao_maps_flutter/Sources/kakao_maps_flutter/KakaoMapController.swift
@@ -196,7 +196,7 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
         case "removeMarkers":
             removeMarkers(call, result)
         case "clearMarkers":
-            clearMarkers(result)
+            clearMarkers(call, result)
         case "getCenter":
             getCenter(result)
         case "toScreenPoint":
@@ -247,6 +247,14 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
             hideLogo(result)
         case "setLogoPosition":
             setLogoPosition(call, result)
+        case "addMarkerLayer":
+            addMarkerLayer(call, result)
+        case "setMarkerLayerVisible":
+            setMarkerLayerVisible(call, result)
+        case "showAllMarkers":
+            showAllMarkers(call, result)
+        case "hideAllMarkers":
+            hideAllMarkers(call, result)
         // LOD Marker APIs
         case "addLodMarkerLayer":
             addLodMarkerLayer(call, result)
@@ -274,6 +282,31 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
             result(FlutterMethodNotImplemented)
         }
     }
+    // MARK: - Add normal LabelLayer
+    private func addMarkerLayer(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let layerId = args["layerId"] as? String, !layerId.isEmpty else {
+            result(FlutterError(code: "E001", message: "Invalid arguments for addMarkerLayer", details: nil))
+            return
+        }
+        withKakaoMapView(result) { view in
+            let manager = view.getLabelManager()
+            if manager.getLabelLayer(layerID: layerId) == nil {
+                let layerOption = LabelLayerOptions(
+                    layerID: layerId,
+                    competitionType: .none,
+                    competitionUnit: .symbolFirst,
+                    orderType: .rank,
+                    zOrder: (args["zOrder"] as? Int) ?? 10000
+                )
+                _ = manager.addLabelLayer(option: layerOption)
+            }
+            if let clickable = args["clickable"] as? Bool, let layer = manager.getLabelLayer(layerID: layerId) {
+                layer.setClickable(clickable)
+            }
+            result(nil)
+        }
+    }
     
     private func withKakaoMapView(
         _ result: @escaping FlutterResult,
@@ -295,16 +328,14 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
     }
     
     private func createLabelLayer(_ layerID: String?) -> LabelLayer? {
+        guard let layerID = layerID, !layerID.isEmpty else { return nil }
         let view = mapController.getView(kKakaoMapViewName) as! KakaoMap
         let manager = view.getLabelManager()
-        let existingLayer = manager.getLabelLayer(layerID: layerID ?? "PoiLayer")
-        
-        if existingLayer != nil {
-            return existingLayer!
+        if let existingLayer = manager.getLabelLayer(layerID: layerID) {
+            return existingLayer
         }
-        
         let layerOption = LabelLayerOptions(
-            layerID: layerID ?? "PoiLayer",
+            layerID: layerID,
             competitionType: .none,
             competitionUnit: .symbolFirst,
             orderType: .rank,
@@ -590,10 +621,13 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
             return
         }
         
+        guard let layerId = args["layerId"] as? String, !layerId.isEmpty else {
+            result(FlutterError(code: "E001", message: "layerId is required for addMarker", details: nil))
+            return
+        }
         withKakaoMapView(result) { view in
             let point = MapPoint(longitude: longitude, latitude: latitude)
-            
-            let labelLayer = createLabelLayer("PoiLayer")
+            let labelLayer = createLabelLayer(layerId)
             guard let targetLayer = labelLayer else {
                 result(FlutterError(code: "E002", message: "Failed to get or create LabelLayer", details: nil))
                 return
@@ -623,8 +657,12 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
             return
         }
         
+        guard let layerId = args["layerId"] as? String, !layerId.isEmpty else {
+            result(FlutterError(code: "E001", message: "layerId is required for removeMarker", details: nil))
+            return
+        }
         withKakaoMapView(result) { view in
-            let labelLayer = createLabelLayer("PoiLayer")
+            let labelLayer = createLabelLayer(layerId)
             guard let targetLayer = labelLayer else {
                 result(FlutterError(code: "E002", message: "Failed to get or create LabelLayer", details: nil))
                 return
@@ -642,8 +680,12 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
             return
         }
         
+        guard let layerId = args["layerId"] as? String, !layerId.isEmpty else {
+            result(FlutterError(code: "E001", message: "layerId is required for addMarkers", details: nil))
+            return
+        }
         withKakaoMapView(result) { view in
-            let labelLayer = createLabelLayer("PoiLayer")
+            let labelLayer = createLabelLayer(layerId)
             guard let targetLayer = labelLayer else {
                 result(FlutterError(code: "E002", message: "Failed to get or create LabelLayer", details: nil))
                 return
@@ -660,7 +702,6 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
                     continue
                 }
                 
-                let point = MapPoint(longitude: longitude, latitude: latitude)
                 let styleId = markerData["styleId"] as? String ?? "__default__"
                 let poiOption = PoiOptions(styleID: styleId, poiID: id)
                 poiOption.clickable = true
@@ -680,6 +721,49 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
                 poiIDs: poiOptions.map(\.itemID!)
             )
             
+            result(nil)
+        }
+    }
+
+    // MARK: - LabelLayer controls (non-LOD)
+    private func setMarkerLayerVisible(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let layerId = args["layerId"] as? String,
+              let visible = args["visible"] as? Bool else {
+            result(FlutterError(code: "E001", message: "Invalid arguments for setMarkerLayerVisible", details: nil))
+            return
+        }
+        withKakaoMapView(result) { view in
+            let manager = view.getLabelManager()
+            if let layer = manager.getLabelLayer(layerID: layerId) {
+                layer.visible = visible
+            }
+            result(nil)
+        }
+    }
+
+    private func showAllMarkers(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let layerId = args["layerId"] as? String else {
+            result(FlutterError(code: "E001", message: "Invalid arguments for showAllMarkers", details: nil))
+            return
+        }
+        withKakaoMapView(result) { view in
+            let manager = view.getLabelManager()
+            manager.getLabelLayer(layerID: layerId)?.showAllPois()
+            result(nil)
+        }
+    }
+
+    private func hideAllMarkers(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let layerId = args["layerId"] as? String else {
+            result(FlutterError(code: "E001", message: "Invalid arguments for hideAllMarkers", details: nil))
+            return
+        }
+        withKakaoMapView(result) { view in
+            let manager = view.getLabelManager()
+            manager.getLabelLayer(layerID: layerId)?.hideAllPois()
             result(nil)
         }
     }
@@ -788,10 +872,18 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
         }
     }
     
-    private func clearMarkers(_ result: @escaping FlutterResult) {
+    private func clearMarkers(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let layerId = args["layerId"] as? String, !layerId.isEmpty else {
+            result(FlutterError(code: "E001", message: "Invalid arguments for clearMarkers", details: nil))
+            return
+        }
         withKakaoMapView(result) { view in
             let manager = view.getLabelManager()
-            manager.clearAllLabelLayers()
+            if let layer = manager.getLabelLayer(layerID: layerId) {
+                layer.clearAllItems()
+                layer.clearAllExitTransitionLodPois()
+            }
             result(nil)
         }
     }

--- a/ios/kakao_maps_flutter/Sources/kakao_maps_flutter/KakaoMapController.swift
+++ b/ios/kakao_maps_flutter/Sources/kakao_maps_flutter/KakaoMapController.swift
@@ -627,9 +627,8 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
         }
         withKakaoMapView(result) { view in
             let point = MapPoint(longitude: longitude, latitude: latitude)
-            let labelLayer = createLabelLayer(layerId)
-            guard let targetLayer = labelLayer else {
-                result(FlutterError(code: "E002", message: "Failed to get or create LabelLayer", details: nil))
+            guard let targetLayer = view.getLabelManager().getLabelLayer(layerID: layerId) else {
+                result(FlutterError(code: "E002", message: "LabelLayer not found: \(layerId)", details: nil))
                 return
             }
             
@@ -662,9 +661,8 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
             return
         }
         withKakaoMapView(result) { view in
-            let labelLayer = createLabelLayer(layerId)
-            guard let targetLayer = labelLayer else {
-                result(FlutterError(code: "E002", message: "Failed to get or create LabelLayer", details: nil))
+            guard let targetLayer = view.getLabelManager().getLabelLayer(layerID: layerId) else {
+                result(FlutterError(code: "E002", message: "LabelLayer not found: \(layerId)", details: nil))
                 return
             }
             
@@ -685,9 +683,8 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
             return
         }
         withKakaoMapView(result) { view in
-            let labelLayer = createLabelLayer(layerId)
-            guard let targetLayer = labelLayer else {
-                result(FlutterError(code: "E002", message: "Failed to get or create LabelLayer", details: nil))
+            guard let targetLayer = view.getLabelManager().getLabelLayer(layerID: layerId) else {
+                result(FlutterError(code: "E002", message: "LabelLayer not found: \(layerId)", details: nil))
                 return
             }
             
@@ -854,20 +851,19 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
     
     private func removeMarkers(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         guard let args = call.arguments as? [String: Any],
-              let ids = args["ids"] as? [String] else {
+              let ids = args["ids"] as? [String],
+              let layerId = args["layerId"] as? String, !layerId.isEmpty else {
             result(FlutterError(code: "E001", message: "Invalid arguments for removeMarkers", details: nil))
             return
         }
         
         withKakaoMapView(result) { view in
-            let labelLayer = createLabelLayer("PoiLayer")
-            guard let targetLayer = labelLayer else {
+            guard let targetLayer = self.createLabelLayer(layerId) else {
                 result(FlutterError(code: "E002", message: "Failed to get or create LabelLayer", details: nil))
                 return
             }
             
             targetLayer.removePois(poiIDs: ids)
-            
             result(nil)
         }
     }

--- a/ios/kakao_maps_flutter/Sources/kakao_maps_flutter/KakaoMapController.swift
+++ b/ios/kakao_maps_flutter/Sources/kakao_maps_flutter/KakaoMapController.swift
@@ -878,7 +878,7 @@ class KakaoMapController: NSObject, FlutterPlatformView, MapControllerDelegate, 
             let manager = view.getLabelManager()
             if let layer = manager.getLabelLayer(layerID: layerId) {
                 layer.clearAllItems()
-                layer.clearAllExitTransitionLodPois()
+                layer.clearAllExitTransitionPois()
             }
             result(nil)
         }

--- a/lib/src/data/lat_lng/lat_lng.dart
+++ b/lib/src/data/lat_lng/lat_lng.dart
@@ -19,10 +19,19 @@ class LatLng extends Data {
   });
 
   /// From JSON map
-  factory LatLng.fromJson(Map<String, Object?> json) => LatLng(
-        latitude: json['latitude']! as double,
-        longitude: json['longitude']! as double,
-      );
+  factory LatLng.fromJson(Map<String, Object?> json) {
+    final latRaw = json['latitude'];
+    final lngRaw = json['longitude'];
+
+    if (latRaw is! num || lngRaw is! num) {
+      throw ArgumentError('Invalid LatLng json: $json');
+    }
+
+    return LatLng(
+      latitude: latRaw.toDouble(),
+      longitude: lngRaw.toDouble(),
+    );
+  }
 
   @override
   Map<String, Object?> toJson() => <String, Object?>{

--- a/lib/src/platform/kakao_map_controller/kakao_map_controller.dart
+++ b/lib/src/platform/kakao_map_controller/kakao_map_controller.dart
@@ -56,6 +56,9 @@ class KakaoMapController extends KakaoMapControllerPlatform {
     required this.viewId,
   }) : _platform = platform;
 
+  /// Android/iOS default layer id
+  static const String defaultLabelLayerId = 'default_label_layer_id';
+
   /// View identifier
   final int viewId;
 
@@ -144,8 +147,10 @@ class KakaoMapController extends KakaoMapControllerPlatform {
   /// - 단일 라벨/마커 추가
   Future<void> addMarker({
     required MarkerOption markerOption,
+    String layerId = KakaoMapController.defaultLabelLayerId,
   }) async {
-    await _platform._callMethod(AddMarker(markerOption: markerOption));
+    await _platform
+        ._callMethod(AddMarker(markerOption: markerOption, layerId: layerId));
   }
 
   /// Remove marker
@@ -156,8 +161,9 @@ class KakaoMapController extends KakaoMapControllerPlatform {
   /// - 마커 id로 제거
   Future<void> removeMarker({
     required String id,
+    String layerId = KakaoMapController.defaultLabelLayerId,
   }) async {
-    await _platform._callMethod(RemoveMarker(id: id));
+    await _platform._callMethod(RemoveMarker(id: id, layerId: layerId));
   }
 
   /// Add markers
@@ -168,8 +174,11 @@ class KakaoMapController extends KakaoMapControllerPlatform {
   /// - 여러 라벨/마커 일괄 추가
   Future<void> addMarkers({
     required List<MarkerOption> markerOptions,
+    String layerId = KakaoMapController.defaultLabelLayerId,
   }) async {
-    await _platform._callMethod(AddMarkers(markerOptions: markerOptions));
+    await _platform._callMethod(
+      AddMarkers(markerOptions: markerOptions, layerId: layerId),
+    );
   }
 
   /// Remove markers
@@ -180,13 +189,16 @@ class KakaoMapController extends KakaoMapControllerPlatform {
   /// - id 목록으로 일괄 제거
   Future<void> removeMarkers({
     required List<String> ids,
+    String layerId = KakaoMapController.defaultLabelLayerId,
   }) async {
-    await _platform._callMethod(RemoveMarkers(ids: ids));
+    await _platform._callMethod(RemoveMarkers(ids: ids, layerId: layerId));
   }
 
-  /// Clear all markers
-  Future<void> clearMarkers() async {
-    await _platform._callMethod(const ClearMarkers());
+  /// Clear all markers in specific layer
+  Future<void> clearMarkers({
+    required String layerId,
+  }) async {
+    await _platform._callMethod(ClearMarkers(layerId: layerId));
   }
 
   /// Register marker styles
@@ -423,6 +435,47 @@ class KakaoMapController extends KakaoMapControllerPlatform {
         alignment: alignment,
         offset: offset,
       ),
+    );
+  }
+
+  // ===== LabelLayer control (non-LOD) =====
+
+  /// Add a normal LabelLayer managed by LabelManager
+  Future<void> addMarkerLayer({
+    required String layerId,
+    int? zOrder,
+    bool? clickable,
+  }) async {
+    await _platform._callMethod(
+      AddMarkerLayer(layerId: layerId, zOrder: zOrder, clickable: clickable),
+    );
+  }
+
+  /// Set layer visible by layerId
+  Future<void> setMarkerLayerVisible({
+    required String layerId,
+    required bool visible,
+  }) async {
+    await _platform._callMethod(
+      SetMarkerLayerVisible(layerId: layerId, visible: visible),
+    );
+  }
+
+  /// Show all markers in the specified layer
+  Future<void> showAllMarkers({
+    required String layerId,
+  }) async {
+    await _platform._callMethod(
+      ShowAllMarkers(layerId: layerId),
+    );
+  }
+
+  /// Hide all markers in the specified layer
+  Future<void> hideAllMarkers({
+    required String layerId,
+  }) async {
+    await _platform._callMethod(
+      HideAllMarkers(layerId: layerId),
     );
   }
 

--- a/lib/src/platform/kakao_map_controller/kakao_map_controller.dart
+++ b/lib/src/platform/kakao_map_controller/kakao_map_controller.dart
@@ -196,7 +196,7 @@ class KakaoMapController extends KakaoMapControllerPlatform {
 
   /// Clear all markers in specific layer
   Future<void> clearMarkers({
-    required String layerId,
+    String layerId = KakaoMapController.defaultLabelLayerId,
   }) async {
     await _platform._callMethod(ClearMarkers(layerId: layerId));
   }

--- a/lib/src/platform/kakao_map_controller/method_channel/method_channel_kakao_map_controller.dart
+++ b/lib/src/platform/kakao_map_controller/method_channel/method_channel_kakao_map_controller.dart
@@ -16,19 +16,24 @@ class MethodChannelKakaoMapController extends KakaoMapControllerPlatform {
           }
 
           if (call.method == 'onLabelClicked') {
-            final event = LabelClickEvent.fromJson(call.arguments);
+            final event =
+                LabelClickEvent.fromJson(_asStringKeyedMap(call.arguments));
             _instance.onLabelClicked(event);
             return;
           }
 
           if (call.method == 'onInfoWindowClicked') {
-            final event = InfoWindowClickEvent.fromJson(call.arguments);
+            final event = InfoWindowClickEvent.fromJson(
+              _asStringKeyedMap(call.arguments),
+            );
             _instance.onInfoWindowClicked(event);
             return;
           }
 
           if (call.method == 'onCameraMoveEnd') {
-            final event = CameraMoveEndEvent.fromJson(call.arguments);
+            final event = CameraMoveEndEvent.fromJson(
+              _asStringKeyedMap(call.arguments),
+            );
             _instance.onCameraMoveEnd(event);
             return;
           }
@@ -60,6 +65,24 @@ class MethodChannelKakaoMapController extends KakaoMapControllerPlatform {
       methodCall.encode(),
     );
 
-    return methodCall.decode(result);
+    return methodCall.decode(_normalizeStandardCodec(result));
+  }
+
+  static Object? _normalizeStandardCodec(Object? value) {
+    if (value is Map) {
+      return value.map<String, Object?>(
+        (key, dynamic val) =>
+            MapEntry(key.toString(), _normalizeStandardCodec(val)),
+      );
+    }
+    if (value is List) {
+      return value.map<Object?>((e) => _normalizeStandardCodec(e)).toList();
+    }
+    return value;
+  }
+
+  static Map<String, Object?> _asStringKeyedMap(Object? arguments) {
+    final normalized = _normalizeStandardCodec(arguments);
+    return (normalized! as Map).cast<String, Object?>();
   }
 }

--- a/lib/src/platform/kakao_map_method_call/kakao_map_method_call.dart
+++ b/lib/src/platform/kakao_map_method_call/kakao_map_method_call.dart
@@ -199,8 +199,11 @@ final class GetCenter extends KakaoMapMethodCall<LatLng?> {
 
   @override
   LatLng? decode(Object? value) {
-    assert(value is Map<String, Object?>);
-    return LatLng.fromJson(value! as Map<String, Object?>);
+    if (value == null || value is! Map<String, Object?>) return null;
+    if (!value.containsKey('latitude') || !value.containsKey('longitude')) {
+      return null;
+    }
+    return LatLng.fromJson(value);
   }
 }
 
@@ -248,12 +251,10 @@ final class FromScreenPoint extends KakaoMapMethodCall<LatLng?> {
 
   @override
   LatLng? decode(Object? value) {
-    if (value is! Map<String, Object?> ||
-        !value.containsKey('latitude') ||
-        !value.containsKey('longitude')) {
+    if (value == null || value is! Map<String, Object?>) return null;
+    if (!value.containsKey('latitude') || !value.containsKey('longitude')) {
       return null;
     }
-
     return LatLng.fromJson(value);
   }
 }

--- a/lib/src/platform/kakao_map_method_call/kakao_map_method_call.dart
+++ b/lib/src/platform/kakao_map_method_call/kakao_map_method_call.dart
@@ -62,11 +62,11 @@ final class MoveCamera extends KakaoMapMethodCall<void> {
 final class AddMarker extends KakaoMapMethodCall<void> {
   const AddMarker({
     required this.markerOption,
-    this.layerId,
+    required this.layerId,
   });
 
   final MarkerOption markerOption;
-  final String? layerId;
+  final String layerId;
 
   @override
   String get name => 'addMarker';
@@ -74,7 +74,7 @@ final class AddMarker extends KakaoMapMethodCall<void> {
   @override
   Map<String, Object?>? encode() {
     final map = Map<String, Object?>.from(markerOption.toJson());
-    if (layerId != null) map['layerId'] = layerId;
+    map['layerId'] = layerId;
     return map;
   }
 }
@@ -82,11 +82,11 @@ final class AddMarker extends KakaoMapMethodCall<void> {
 final class RemoveMarker extends KakaoMapMethodCall<void> {
   const RemoveMarker({
     required this.id,
-    this.layerId,
+    required this.layerId,
   });
 
   final String id;
-  final String? layerId;
+  final String layerId;
 
   @override
   String get name => 'removeMarker';
@@ -94,18 +94,18 @@ final class RemoveMarker extends KakaoMapMethodCall<void> {
   @override
   Map<String, Object?>? encode() => {
         'id': id,
-        if (layerId != null) 'layerId': layerId,
+        'layerId': layerId,
       };
 }
 
 final class AddMarkers extends KakaoMapMethodCall<void> {
   const AddMarkers({
     required this.markerOptions,
-    this.layerId,
+    required this.layerId,
   });
 
   final List<MarkerOption> markerOptions;
-  final String? layerId;
+  final String layerId;
 
   @override
   String get name => 'addMarkers';
@@ -113,18 +113,18 @@ final class AddMarkers extends KakaoMapMethodCall<void> {
   @override
   Map<String, Object?>? encode() => {
         'markers': markerOptions.map((e) => e.toJson()).toList(),
-        if (layerId != null) 'layerId': layerId,
+        'layerId': layerId,
       };
 }
 
 final class RemoveMarkers extends KakaoMapMethodCall<void> {
   const RemoveMarkers({
     required this.ids,
-    this.layerId,
+    required this.layerId,
   });
 
   final List<String> ids;
-  final String? layerId;
+  final String layerId;
 
   @override
   String get name => 'removeMarkers';
@@ -132,7 +132,7 @@ final class RemoveMarkers extends KakaoMapMethodCall<void> {
   @override
   Map<String, Object?>? encode() => {
         'ids': ids,
-        if (layerId != null) 'layerId': layerId,
+        'layerId': layerId,
       };
 }
 

--- a/lib/src/platform/kakao_map_method_call/kakao_map_method_call.dart
+++ b/lib/src/platform/kakao_map_method_call/kakao_map_method_call.dart
@@ -62,37 +62,50 @@ final class MoveCamera extends KakaoMapMethodCall<void> {
 final class AddMarker extends KakaoMapMethodCall<void> {
   const AddMarker({
     required this.markerOption,
+    this.layerId,
   });
 
   final MarkerOption markerOption;
+  final String? layerId;
 
   @override
   String get name => 'addMarker';
 
   @override
-  Map<String, Object?>? encode() => markerOption.toJson();
+  Map<String, Object?>? encode() {
+    final map = Map<String, Object?>.from(markerOption.toJson());
+    if (layerId != null) map['layerId'] = layerId;
+    return map;
+  }
 }
 
 final class RemoveMarker extends KakaoMapMethodCall<void> {
   const RemoveMarker({
     required this.id,
+    this.layerId,
   });
 
   final String id;
+  final String? layerId;
 
   @override
   String get name => 'removeMarker';
 
   @override
-  Map<String, Object?>? encode() => {'id': id};
+  Map<String, Object?>? encode() => {
+        'id': id,
+        if (layerId != null) 'layerId': layerId,
+      };
 }
 
 final class AddMarkers extends KakaoMapMethodCall<void> {
   const AddMarkers({
     required this.markerOptions,
+    this.layerId,
   });
 
   final List<MarkerOption> markerOptions;
+  final String? layerId;
 
   @override
   String get name => 'addMarkers';
@@ -100,31 +113,39 @@ final class AddMarkers extends KakaoMapMethodCall<void> {
   @override
   Map<String, Object?>? encode() => {
         'markers': markerOptions.map((e) => e.toJson()).toList(),
+        if (layerId != null) 'layerId': layerId,
       };
 }
 
 final class RemoveMarkers extends KakaoMapMethodCall<void> {
   const RemoveMarkers({
     required this.ids,
+    this.layerId,
   });
 
   final List<String> ids;
+  final String? layerId;
 
   @override
   String get name => 'removeMarkers';
 
   @override
-  Map<String, Object?>? encode() => {'ids': ids};
+  Map<String, Object?>? encode() => {
+        'ids': ids,
+        if (layerId != null) 'layerId': layerId,
+      };
 }
 
 final class ClearMarkers extends KakaoMapMethodCall<void> {
-  const ClearMarkers();
+  const ClearMarkers({required this.layerId});
+
+  final String layerId;
 
   @override
   String get name => 'clearMarkers';
 
   @override
-  Map<String, Object?>? encode() => null;
+  Map<String, Object?>? encode() => {'layerId': layerId};
 }
 
 // Marker Style Registration Methods
@@ -744,5 +765,80 @@ final class SetLodMarkerLayerClickable extends KakaoMapMethodCall<void> {
   Map<String, Object?>? encode() => {
         'layerId': layerId,
         'clickable': clickable,
+      };
+}
+
+// ===== LabelLayer control (non-LOD) =====
+
+final class AddMarkerLayer extends KakaoMapMethodCall<void> {
+  const AddMarkerLayer({
+    required this.layerId,
+    this.zOrder,
+    this.clickable,
+  });
+
+  final String layerId;
+  final int? zOrder;
+  final bool? clickable;
+
+  @override
+  String get name => 'addMarkerLayer';
+
+  @override
+  Map<String, Object?>? encode() => {
+        'layerId': layerId,
+        if (zOrder != null) 'zOrder': zOrder,
+        if (clickable != null) 'clickable': clickable,
+      };
+}
+
+final class SetMarkerLayerVisible extends KakaoMapMethodCall<void> {
+  const SetMarkerLayerVisible({
+    required this.layerId,
+    required this.visible,
+  });
+
+  final String layerId;
+  final bool visible;
+
+  @override
+  String get name => 'setMarkerLayerVisible';
+
+  @override
+  Map<String, Object?>? encode() => {
+        'layerId': layerId,
+        'visible': visible,
+      };
+}
+
+final class ShowAllMarkers extends KakaoMapMethodCall<void> {
+  const ShowAllMarkers({
+    required this.layerId,
+  });
+
+  final String layerId;
+
+  @override
+  String get name => 'showAllMarkers';
+
+  @override
+  Map<String, Object?>? encode() => {
+        'layerId': layerId,
+      };
+}
+
+final class HideAllMarkers extends KakaoMapMethodCall<void> {
+  const HideAllMarkers({
+    required this.layerId,
+  });
+
+  final String layerId;
+
+  @override
+  String get name => 'hideAllMarkers';
+
+  @override
+  Map<String, Object?>? encode() => {
+        'layerId': layerId,
       };
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 요약
카카오맵 Flutter 플러그인의 마커 레이어(LabelLayer) 관리 기능을 대폭 개선했습니다. 모든 마커 작업에 `layerId` 명시를 필수로 하여 API를 통일하고, 레이어 생성/표시/숨기기/삭제 메서드를 추가했습니다.

## 🔗 관련 이슈
- Closes #

## 🎯 기능 상세 설명

### 주요 변경사항
- **마커 레이어 관리 API 추가**
 - `addMarkerLayer`: 마커 레이어 생성
 - `setMarkerLayerVisible`: 레이어 표시/숨기기
 - `showAllMarkers`/`hideAllMarkers`: 모든 마커 일괄 제어
 - Android/iOS 양쪽 플랫폼 구현 완료

- **API 통일 및 Breaking Changes**
 - 모든 마커 메서드에 `layerId` 매개변수 필수화
 - `addMarker`, `removeMarker`, `addMarkers`, `removeMarkers`, `clearMarkers` 시그니처 변경
 - 레이어가 없을 때 적절한 에러 처리 추가

- **코드 개선사항**
 - Android: `getOrCreateLabelLayer` 헬퍼 메서드 추가
 - iOS: 암시적 레이어 생성 제거, 명시적 에러 처리
 - Null 안전성 개선 (좌표 변환 메서드)

- **예제 앱 업데이트**
 - 마커 추가 전 명시적 레이어 생성 데모
 - SnackBar 동작을 `floating`으로 변경 (UI 개선)

### 📱 스크린샷/데모
<!-- UI 변경이 있다면 설명해주세요 -->

### 💥 Breaking Changes
- 모든 마커 관련 메서드에 `layerId` 매개변수가 필수가 되었습니다.
- 마이그레이션: 마커 작업 전 `addMarkerLayer`로 레이어를 먼저 생성해야 합니다.

### 🧪 테스트
- [ ] 단위 테스트 추가
- [ ] 위젯 테스트 추가
- [x] 예제 앱에서 테스트
- [x] 다양한 플랫폼에서 테스트 (Android/iOS)

### 📚 문서 업데이트
- [ ] README.md 업데이트
- [ ] API 문서 업데이트
- [x] 예제 코드 추가

### ✅ 체크리스트
- [x] 코드 스타일 가이드 준수
- [x] 자체 리뷰 완료
- [ ] 테스트 추가 및 통과
- [ ] 문서 업데이트
- [x] 예제 앱에서 동작 확인